### PR TITLE
Add onSceneSpawnActors hook and spawn Gold Skulltulas during day

### DIFF
--- a/soh/soh/Enhancements/game-interactor/GameInteractor.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor.h
@@ -88,6 +88,7 @@ public:
     DEFINE_HOOK(OnGameFrameUpdate, void());
     DEFINE_HOOK(OnReceiveItem, void(uint8_t item));
     DEFINE_HOOK(OnSceneInit, void(int16_t sceneNum));
+    DEFINE_HOOK(OnSceneSpawnActors, void());
     DEFINE_HOOK(OnPlayerUpdate, void());
     
     DEFINE_HOOK(OnSaveFile, void(int32_t fileNum));

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.cpp
@@ -22,6 +22,10 @@ void GameInteractor_ExecuteOnSceneInitHooks(int16_t sceneNum) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSceneInit>(sceneNum);
 }
 
+void GameInteractor_ExecuteOnSceneSpawnActors() {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSceneSpawnActors>();
+}
+
 void GameInteractor_ExecuteOnPlayerUpdate() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerUpdate>();
 }

--- a/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
+++ b/soh/soh/Enhancements/game-interactor/GameInteractor_Hooks.h
@@ -6,6 +6,7 @@ extern "C" void GameInteractor_ExecuteOnExitGame(int32_t fileNum);
 extern "C" void GameInteractor_ExecuteOnGameFrameUpdate();
 extern "C" void GameInteractor_ExecuteOnReceiveItemHooks(uint8_t item);
 extern "C" void GameInteractor_ExecuteOnSceneInit(int16_t sceneNum);
+extern "C" void GameInteractor_ExecuteOnSceneSpawnActors();
 extern "C" void GameInteractor_ExecuteOnPlayerUpdate();
 
 // MARK: -  Save Files

--- a/soh/soh/Enhancements/mods.cpp
+++ b/soh/soh/Enhancements/mods.cpp
@@ -12,6 +12,8 @@ extern PlayState* gPlayState;
 extern void Play_PerformSave(PlayState* play);
 extern s32 Health_ChangeBy(PlayState* play, s16 healthChange);
 extern void Rupees_ChangeBy(s16 rupeeChange);
+extern Actor* Actor_Spawn(ActorContext* actorCtx, PlayState* play, s16 actorId, f32 posX, f32 posY, f32 posZ,
+                            s16 rotX, s16 rotY, s16 rotZ, s16 params, s16 canRandomize);
 }
 
 void RegisterInfiniteMoney() {
@@ -258,6 +260,57 @@ void RegisterRupeeDash() {
     });
 }
 
+struct DayTimeGoldSkulltulas {
+    uint16_t scene;
+    uint16_t room;
+    bool forChild;
+    std::vector<ActorEntry> actorEntries;
+};
+
+using DayTimeGoldSkulltulasList = std::vector<DayTimeGoldSkulltulas>;
+
+void RegisterDaytimeGoldSkultullas() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneSpawnActors>([]() {
+        if (!CVarGetInteger("gNightGSAlwaysSpawn", 0)) {
+            return;
+        }
+
+        // Gold Skulltulas that are not part of the scene actor list during the day
+        // Actor values copied from the night time scene actor list
+        static const DayTimeGoldSkulltulasList dayTimeGoldSkulltulas = {
+            // Graveyard
+            { SCENE_SPOT02, 1, true,  { {ACTOR_EN_SW, {156, 315, 795}, {16384, -32768, 0}, -20096} } },
+            // ZF
+            { SCENE_SPOT08, 0, true,  { {ACTOR_EN_SW, {-1891, 187, 1911}, {16384, 18022, 0}, -19964} } },
+            // GF
+            { SCENE_SPOT12, 0, false, { {ACTOR_EN_SW, {1598, 999, -2008}, {16384, -16384, 0}, -19198} } },
+            { SCENE_SPOT12, 1, false, { {ACTOR_EN_SW, {3377, 1734, -4935}, {16384, 0, 0}, -19199} } },
+            // Kak
+            { SCENE_SPOT01, 0, false, { {ACTOR_EN_SW, {-18, 540, 1800}, {0, -32768, 0}, -20160} } },
+            { SCENE_SPOT01, 0, true,  { {ACTOR_EN_SW, {-465, 377, -888}, {0, 28217, 0}, -20222},
+                                        {ACTOR_EN_SW, {5, 686, -171}, {0, -32768, 0}, -20220},
+                                        {ACTOR_EN_SW, {324, 270, 905}, {16384, 0, 0}, -20216},
+                                        {ACTOR_EN_SW, {-602, 120, 1120}, {16384, 0, 0}, -20208} } },
+            // LLR
+            { SCENE_SPOT20, 0, true,  { {ACTOR_EN_SW, {-2344, 180, 672}, {16384, 22938, 0}, -29695},
+                                        {ACTOR_EN_SW, {808, 48, 326}, {16384, 0, 0}, -29694},
+                                        {ACTOR_EN_SW, {997, 286, -2698}, {16384, -16384, 0}, -29692} } },
+        };
+
+        for (auto dayTimeGS : dayTimeGoldSkulltulas) {
+            if (IS_DAY && dayTimeGS.forChild == LINK_IS_CHILD &&
+                dayTimeGS.scene == gPlayState->sceneNum &&
+                dayTimeGS.room == gPlayState->roomCtx.curRoom.num) {
+                for (auto actorEntry : dayTimeGS.actorEntries) {
+                    Actor_Spawn(&gPlayState->actorCtx, gPlayState, actorEntry.id, actorEntry.pos.x, actorEntry.pos.y,
+                                actorEntry.pos.z, actorEntry.rot.x, actorEntry.rot.y, actorEntry.rot.z,
+                                actorEntry.params, false);
+                }
+            }
+        }
+    });
+}
+
 void InitMods() {
     RegisterTTS();
     RegisterInfiniteMoney();
@@ -272,4 +325,5 @@ void InitMods() {
     RegisterSwitchAge();
     RegisterRupeeDash();
     RegisterAutoSave();
+    RegisterDaytimeGoldSkultullas();
 }

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2515,6 +2515,7 @@ void Actor_UpdateAll(PlayState* play, ActorContext* actorCtx) {
             Actor_SpawnEntry(&play->actorCtx, actorEntry++, play);
         }
         play->numSetupActors = 0;
+        GameInteractor_ExecuteOnSceneSpawnActors();
     }
 
     if (actorCtx->unk_02 != 0) {


### PR DESCRIPTION
This PR adds a new `onSceneSpawnActors` hook that runs when you transition scenes/rooms, and the original actor spawn list for that room is spawned.

With this hook we can then do various things like spawning "extra" actors.

I've added an implementation of this hook for the "Night time GS always spawn" enhancement that will spawn Gold Skulltulas into they Day scene equivalent that are missing.

There where 5 unique scenes (7 including different ages), with 12 unique GS actors overall that need to be spawned to make this enhancement work for all GS in the game. I ripped the position/rotation/params values from the Night scene spawn actor list.