### PR TITLE
Handle the kak tree skull during the day

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/soh/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -173,6 +173,15 @@ void EnWood02_Init(Actor* thisx, PlayState* play2) {
     f32 floorY;
     s16 extraRot;
 
+    // The tree in Kakariko's day scene does not have the same params to spawn the GS
+    // as the night scene, For the always spawn GS enhancement we apply the needed
+    // params to have the GS drop when bonking
+    if ((this->actor.params & 0xFF) == WOOD_TREE_CONICAL_MEDIUM && IS_DAY &&
+        play->sceneNum == SCENE_SPOT01 && CVarGetInteger("gNightGSAlwaysSpawn", 0)) {
+        this->actor.params = 0x2001;
+        this->actor.home.rot.z = 0x71;
+    }
+
     spawnType = WOOD_SPAWN_NORMAL;
     actorScale = 1.0f;
     this->unk_14C = (this->actor.params >> 8) & 0xFF;


### PR DESCRIPTION
Makes it so the kak day tree has the same params so bonking it causes the skull to appear

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux-compatibility.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/594296479.zip)
  - [soh-linux-performance.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/594296480.zip)
  - [soh-mac.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/594296481.zip)
  - [soh-switch.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/594296482.zip)
  - [soh-wiiu.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/594296483.zip)
  - [soh-windows.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/594296484.zip)
<!--- section:artifacts:end -->