### PR TITLE
[Time Saver] Faster Bean Patch GS Spawn 

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -667,6 +667,8 @@ void DrawEnhancementsMenu() {
                     "- Not within range of Ocarina playing spots");
                 UIWidgets::PaddedEnhancementCheckbox("Pause Warp", CVAR_ENHANCEMENT("PauseWarp"), true, false);
                 UIWidgets::Tooltip("Selection of warp song in pause menu initiates warp. Disables song playback.");
+                UIWidgets::PaddedEnhancementCheckbox("Faster Bean Patch Skulltulas", CVAR_ENHANCEMENT("FastBeanSkullSpawn"), true, false);
+                UIWidgets::Tooltip("Makes the Gold Skulltulas from bean patches come out faster after the bugs dig into the center.");
                 
                 ImGui::EndTable();
                 ImGui::EndMenu();

--- a/soh/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
+++ b/soh/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
@@ -46,6 +46,12 @@ void ObjMakekinsuta_Init(Actor* thisx, PlayState* play) {
 }
 
 void func_80B98320(ObjMakekinsuta* this, PlayState* play) {
+
+    // Forces the timer to be 60 to make the Gold Skulltula spawn instantly out of the soil patch
+    if (CVarGetInteger(CVAR_ENHANCEMENT("FastBeanSkullSpawn"), 0)) {
+        this->timer = 60;
+    }
+
     if (this->unk_152 != 0) {
         if (this->timer >= 60 && !func_8002DEEC(GET_PLAYER(play))) {
             Actor_Spawn(&play->actorCtx, play, ACTOR_EN_SW, this->actor.world.pos.x, this->actor.world.pos.y,


### PR DESCRIPTION
Makes the Gold Skulltulas from bean patches come out faster after the bugs dig into the center

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/2003273172.zip)
  - [soh-linux.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/2003318636.zip)
  - [soh-windows.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/2003334362.zip)
  - [soh-mac.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/2003424617.zip)
<!--- section:artifacts:end -->