### PR TITLE
[Time Saver] Empty Bottles Faster

### DIFF
--- a/soh/soh/SohMenuBar.cpp
+++ b/soh/soh/SohMenuBar.cpp
@@ -667,6 +667,8 @@ void DrawEnhancementsMenu() {
                     "- Not within range of Ocarina playing spots");
                 UIWidgets::PaddedEnhancementCheckbox("Pause Warp", CVAR_ENHANCEMENT("PauseWarp"), true, false);
                 UIWidgets::Tooltip("Selection of warp song in pause menu initiates warp. Disables song playback.");
+                UIWidgets::PaddedEnhancementCheckbox("Empty Bottles Faster", CVAR_ENHANCEMENT("FastBottleEmpty"), true, false);
+                UIWidgets::Tooltip("Speeds up the bottle emptying animation when dumping out the contents of a bottle.");
                 
                 ImGui::EndTable();
                 ImGui::EndMenu();

--- a/soh/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/soh/src/overlays/actors/ovl_player_actor/z_player.c
@@ -14057,6 +14057,15 @@ static AnimSfxEntry D_80854A34[] = {
 void Player_Action_8084EFC0(Player* this, PlayState* play) {
     func_8083721C(this);
 
+    //Speeds up bottle emptying animation without making it look too out of place
+    if (CVarGetInteger(CVAR_ENHANCEMENT("FastBottleEmpty"), 0)) {
+        if (this->skelAnime.curFrame <= 60.0f) {
+            this->skelAnime.playSpeed = 3.0f;
+        } else {
+            this->skelAnime.playSpeed = 1.0f;
+        }
+    }
+
     if (LinkAnimation_Update(play, &this->skelAnime)) {
         func_8083C0E8(this, play);
         func_8005B1A4(Play_GetCamera(play, 0));


### PR DESCRIPTION
Speeds up the animation when dumping out the contents of a bottle, like fish, bugs, and blue fire. Does not affect fairies, drinkables, or cutscene activating bottle contents.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/2003281563.zip)
  - [soh-linux.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/2003328681.zip)
  - [soh-windows.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/2003338161.zip)
  - [soh-mac.zip](https://nightly.link/Patrick12115/Shipwright/actions/artifacts/2003430224.zip)
<!--- section:artifacts:end -->